### PR TITLE
Call reset logic on remove search string from keyboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
+<a name="1.6.1"></a>
+## [1.6.1](https://github.com/MyBook/selfpub-ui/compare/v1.6.0...v1.6.1) (2018-17-09)
+
+### Fix
+
+* Call reset logic for Search-box component on remove search string from keyboard
+
 <a name="1.6.0"></a>
-## [1.6.0](https://github.com/MyBook/selfpub-ui/compare/v1.5.1...v1.6.0) (2018-14-09)
+## [1.6.0](https://github.com/MyBook/selfpub-ui/compare/v1.5.1...v1.6.0) (2018-17-09)
 
 ### Features
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@selfpub/selfpub-ui",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Design system implementation. Component library Selfpub",
   "homepage": "https://mybook.github.io/selfpub-ui/",
   "main": "src/components/index.js",

--- a/src/components/search-box/search-box.js
+++ b/src/components/search-box/search-box.js
@@ -113,7 +113,9 @@ export default class SearchBox extends Component {
   };
 
   onType = (event, value) => {
-    if (value.length < this.minimalValue) {
+    if (value.length === 0) {
+      this.reset();
+    } else if (value.length < this.minimalValue) {
       this.updateSearchString(value);
     } else {
       this.updateSearchString(


### PR DESCRIPTION
# PR Details

Call logic reset for `<SearchBox />` component on clearing input form keyboard

## Related Issue
Issue: #17 

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)

**Closing issues**

closes #17 
